### PR TITLE
rename-crawler-service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2'
-services: 
-  vscovid-crawler:
+services:
+  crawler:
     build: .
-    volumes: 
+    volumes:
       - .:/home/ubuntu/vscovid-crawler
     ports:
       - "8080:80"


### PR DESCRIPTION
- docker-compose が諸々（Image や Volume, Network など）の prefix にプロジェクト名を付けてくれるし、`docker-compose run/exec/ps` などを叩く際に楽になるので、デカすぎる名前にならなければ短い方がよさそう

example:
~~~diff
- docker-compose run --rm vscovid-crawler bash
+ docker-compose run --rm crawler bash
~~~
~~~sh
🧸 sarabi-mastiff.lan:covid19-surveyor
$ docker inspect $(docker-compose ps -q crawler) | jq '{ Image: .[].Config.Image, Name: .[].Name, Project: .[].Config.Labels["com.docker.compose.project"] }'
{
  "Image": "covid19-surveyor_crawler",
  "Name": "/covid19-surveyor_crawler_1",
  "Project": "covid19-surveyor"
}
~~~