### PR TITLE
PDFファイルをgrep対象にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ www-data/*.jp
 www-data/wget-log*
 *.jp
 grep_*
+!grep_test.sh
 *.swp
 *.tmp
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
       fcgiwrap \
       squid \
       redis-tools \
+      poppler-utils \
       && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cp .wgetrc ~/
 ```
 
 ## Setup for macOS
-- `brew install wget jq nginx fcgiwrap squid`
+- `brew install wget jq nginx fcgiwrap squid poppler`
 
 ### Install GNU xargs in macOS
 

--- a/crawler/grep.sh
+++ b/crawler/grep.sh
@@ -74,10 +74,12 @@ export_corona_files() {
 }
 
 export_pdf_corona_files() {
-	find ./www-data/ -regex '.*\.pdf$' | xargs -n1 pdftotext
+	find ./www-data/ -regex '.*\.pdf$' | xargs -n1 -I@ pdftotext @ @.txt
 	set +e
-	grep -r コロナ --include="*.txt" ./www-data | sanitize_grep_result >>\
-	$INTERMEDIATE_FILE_PATH
+	grep -r コロナ --include="*.pdf.txt" ./www-data |\
+		sanitize_grep_result |\
+		sed 's/\.pdf\.txt:/\.pdf:/' >>\
+		$INTERMEDIATE_FILE_PATH
 	set -e
 }
 

--- a/crawler/grep.sh
+++ b/crawler/grep.sh
@@ -6,12 +6,11 @@ set -e
 ### ./www-dataに収集した全サイトから新型コロナウイルスに関連するHTMLファイルの一覧を取得するスクリプト
 ###
 ### Usage
-### ./grep.sh
 ### ./crawler/grep.sh ${DATA_PATH}
 ###
 
 # 配列初期化
-words=`cat <<EOM
+export WORDS=`cat <<EOM
 助成
 補助
 給付
@@ -43,30 +42,64 @@ words=`cat <<EOM
 EOM
 `
 
+export INTERMEDIATE_FILE_PATH="./tmp/grep_コロナ.txt.tmp"
 
-rm -f www-data/index.html
+remove_exist_index() {
+	rm -f www-data/index.html
+}
 
-set +e
-# www-data内の全HTMLファイルをコロナでgrepして中間ファイルに出力
-grep -r コロナ --include="*.html" ./www-data |\
-# 長過ぎる行は無視
-sed '/^.\{1,200\}$/!d' |\
-# 半角スペース除去
-sed 's/ //g' |\
-# 全角スペース除去
-sed 's/　//g' |\
-# タブ除去
-sed 's/[ \t]*//g' |\
-# HTMLタグ除去
-sed -e 's/<[^>]*>//g' >\
-./tmp/grep_コロナ.txt.tmp
-set -e
+init_intermediate_file() {
+    echo "" > $INTERMEDIATE_FILE_PATH
+}
+
+sanitize_grep_result() {
+	# 長過ぎる行は無視
+	sed '/^.\{1,200\}$/!d' |\
+	# 半角スペース除去
+	sed 's/ //g' |\
+	# 全角スペース除去
+	sed 's/　//g' |\
+	# タブ除去
+	sed 's/[ \t]*//g' |\
+	# HTMLタグ除去
+	sed -e 's/<[^>]*>//g'
+}
+
+export_corona_files() {
+	set +e
+	# www-data内の全HTMLファイルをコロナでgrepして中間ファイルに出力
+	grep -r コロナ --include="*.html" ./www-data | sanitize_grep_result >>\
+	$INTERMEDIATE_FILE_PATH
+	set -e
+}
+
+export_pdf_corona_files() {
+	find ./www-data/ -regex '.*\.pdf$' | xargs -n1 pdftotext
+	set +e
+	grep -r コロナ --include="*.txt" ./www-data | sanitize_grep_result >>\
+	$INTERMEDIATE_FILE_PATH
+	set -e
+}
+
+export_keyword_files()  {
+	set +e
+	for word in ${WORDS}; do
+		echo $word
+		# 中間ファイルを各キーワードでgrepして結果を出力
+		grep $word $INTERMEDIATE_FILE_PATH > ./tmp/grep_コロナ_$word.txt.tmp
+	done
+	set -e
+}
+
+main() {
+	remove_exist_index
+	init_intermediate_file
+	export_corona_files
+	export_pdf_corona_files
+	export_keyword_files
+}
 
 
-set +e
-for word in ${words}; do
-	echo $word
-	# 中間ファイルを各キーワードでgrepして結果を出力
-	grep $word ./tmp/grep_コロナ.txt.tmp > ./tmp/grep_コロナ_$word.txt.tmp
-done
-set -e
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main $@
+fi

--- a/crawler/grep.sh
+++ b/crawler/grep.sh
@@ -7,6 +7,7 @@ set -e
 ###
 ### Usage
 ### ./grep.sh
+### ./crawler/grep.sh ${DATA_PATH}
 ###
 
 # 配列初期化

--- a/test/grep_test.sh
+++ b/test/grep_test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+. ./crawler/grep.sh
+
+# test sanitize_grep_result
+## remove whitespace chars
+input="foo.html:あいうえお　かきくけこ さしすせそ	たちつてと"
+result=$(echo $input | sanitize_grep_result)
+echo $result
+expect="foo.html:あいうえおかきくけこさしすせそたちつてと"
+echo $expect
+if [ "$result" = "$expect" ]; then
+	echo "passed"
+else
+	echo "failed"
+	exit 1
+fi
+
+## remove too long line
+input="foo.html:$(seq 100 | xargs)"
+result=$(echo $input | sanitize_grep_result)
+echo $result
+expect=""
+echo $expect
+if [ "$result" = "$expect" ]; then
+	echo "passed"
+else
+	echo "failed"
+	exit 1
+fi
+
+## sanitize HTML tags
+input="foo.html:<p><a href=\"bar.html\">テキストテキスト<br>テキスト</a></p>"
+result=$(echo $input | sanitize_grep_result)
+echo $result
+expect="foo.html:テキストテキストテキスト"
+echo $expect
+if [ "$result" = "$expect" ]; then
+	echo "passed"
+else
+	echo "failed"
+	exit 1
+fi


### PR DESCRIPTION
closes #5 

### やったこと
 
- `grep.sh` の実装の関数化（やりすぎている節がある）
- PDF を grep の対象にする

### 残タスク
- [x] PDF ファイルが rename される都合元のURLを保持できていない
    - `pdftotext` が `foo.pdf` を `foo.txt` にするため
    - とはいえクロールしたファイルに上書きをするのも怖いのでどうしたものか考え中
- [x] テストの追加( `sanitize_grep_result` とか )