### PR TITLE
make wget 時に remove-large-files を続けて実行

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ test:
 .PHONY: wget
 wget:
 	./crawler/wget.sh data/gov.csv data/pref.csv data/city.csv
+	./crawler/remove-large-files.sh
 
 .PHONY: remove-large-files
 remove-large-files:

--- a/USAGE
+++ b/USAGE
@@ -40,3 +40,4 @@ USAGE
 
     make slack-check-results
         slackで質問DMを送って回答された結果の一覧を表示します
+


### PR DESCRIPTION
close #86 

`make wget` 後に自動で remove-large-files 処理（大容量の不要ファイル削除処理）も実行させる。
こうしておくと手動で `make remove-large-files` する必要がなくなる。

※ とはいえ単体の `make remove-large-files` も実行したいケースはあると思うので、そちらも残しておく。