### PR TITLE
テスト改善の続き：assert系関数の導入

### DIFF
--- a/lib/helper.sh
+++ b/lib/helper.sh
@@ -69,7 +69,7 @@ assert_not_empty(){
 	actual=$1
 
 	# 判定
-	if [ -n "$actual" ]; then
+	if [ "$actual" != "" ]; then
 		test_passed
 	else
 		test_failed "(not empty)" "$actual"

--- a/lib/helper.sh
+++ b/lib/helper.sh
@@ -16,7 +16,7 @@ echo_red() {
 # -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- #
 # テスト成功出力
 test_passed(){
-	echo_green "    passed"
+	echo_green "\tpassed"
 	return 0
 }
 
@@ -27,9 +27,9 @@ test_failed(){
 	actual=$2
 
 	# 出力
-	echo_red   "    failed"
-	echo       "        expect: $expect"
-	echo       "        actual: $actual"
+	echo_red   "\tfailed"
+	echo -e    "\t\texpect: $expect"
+	echo -e    "\t\tactual: $actual"
 	exit 1
 }
 

--- a/lib/helper.sh
+++ b/lib/helper.sh
@@ -11,6 +11,9 @@ echo_red() {
     return 0
 }
 
+# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- #
+# テスト結果出力
+# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- #
 # テスト成功出力
 test_passed(){
 	echo_green "    passed"
@@ -18,13 +21,59 @@ test_passed(){
 }
 
 # テストエラー出力（exit 1 までしてしまう）
-#   第1引数: expect value
-#   第2引数: actual value
 test_failed(){
+	# 引数
+	expect=$1
+	actual=$2
+
+	# 出力
 	echo_red   "    failed"
-	echo       "        expect: $1"
-	echo       "        actual: $2"
+	echo       "        expect: $expect"
+	echo       "        actual: $actual"
 	exit 1
+}
+
+# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- #
+# Assert 系の関数
+# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- #
+# 2値が等しいことを確認
+assert_equal(){
+	# 引数
+	expect=$1
+	actual=$2
+
+	# 判定
+	if [ "$actual" = "$expect" ]; then
+		test_passed
+	else
+		test_failed "$expect" "$actual"
+	fi
+}
+
+# 値が空っぽであることを確認
+assert_empty(){
+	# 引数
+	actual=$1
+
+	# 判定
+	if [ "$actual" = "" ]; then
+		test_passed
+	else
+		test_failed "(empty)" "$actual"
+	fi
+}
+
+# 値が空っぽでないことを確認
+assert_not_empty(){
+	# 引数
+	actual=$1
+
+	# 判定
+	if [ -n "$actual" ]; then
+		test_passed
+	else
+		test_failed "(not empty)" "$actual"
+	fi
 }
 
 # helper.sh が直接実行されたら exit 0 する

--- a/test/grep_test.sh
+++ b/test/grep_test.sh
@@ -9,31 +9,16 @@ echo test sanitize_grep_result
 ## remove whitespace chars
 input="foo.html:あいうえお　かきくけこ さしすせそ	たちつてと"
 actual=$(echo $input | sanitize_grep_result)
-expect="foo.html:あいうえおかきくけこさしすせそたちつてと"
-if [ "$actual" = "$expect" ]; then
-	test_passed
-else
-	test_failed "$expect" "$actual"
-fi
+assert_equal "foo.html:あいうえおかきくけこさしすせそたちつてと" "$actual"
 
 echo test sanitize_grep_result
 ## remove too long line
 input="foo.html:$(seq 100 | xargs)"
 actual=$(echo $input | sanitize_grep_result)
-expect=""
-if [ "$actual" = "$expect" ]; then
-	test_passed
-else
-	test_failed "$expect" "$actual"
-fi
+assert_empty "$actual"
 
 echo test sanitize_grep_result
 ## sanitize HTML tags
 input="foo.html:<p><a href=\"bar.html\">テキストテキスト<br>テキスト</a></p>"
 actual=$(echo $input | sanitize_grep_result)
-expect="foo.html:テキストテキストテキスト"
-if [ "$actual" = "$expect" ]; then
-	test_passed
-else
-	test_failed "$expect" "$actual"
-fi
+assert_equal "foo.html:テキストテキストテキスト" "$actual"

--- a/test/url-map_test.sh
+++ b/test/url-map_test.sh
@@ -15,7 +15,6 @@ echo test get_members_list
 ## setup
 rm -f "tmp/members_list.json"
 channels_id=`get_channels_id`
-# TODO: 要修正。この行で「jq: error (at <stdin>:1): Cannot iterate over null (null)」というエラー出力が出ています。
 actual=`get_members_list $channels_id`
 assert_not_empty "${#actual}"
 

--- a/test/url-map_test.sh
+++ b/test/url-map_test.sh
@@ -9,51 +9,29 @@ echo test get_channels_id
 ## setup
 rm -f "tmp/channels_list.json"
 actual=`get_channels_id`
-if [ -n "${#actual}" ]; then
-	test_passed
-else
-	test_failed "not null" "$actual"
-fi
+assert_not_empty "${#actual}"
 
 echo test get_members_list
 ## setup
 rm -f "tmp/members_list.json"
 channels_id=`get_channels_id`
+# TODO: 要修正。この行で「jq: error (at <stdin>:1): Cannot iterate over null (null)」というエラー出力が出ています。
 actual=`get_members_list $channels_id`
-if [ "$actual" != "" ]; then
-	test_passed
-else
-	test_failed "not null" "$actual"
-fi
+assert_not_empty "${#actual}"
 
 
 
 echo test get_title_by_res
 res=`wget -q -O - https://kantei.go.jp`
-actual=`get_title_by_res "$res"`
-expect="首相官邸ホームページ"
-if [ "$actual" = "$expect" ]; then
-	test_passed
-else
-	test_failed "$expect" "$actual"
-fi
+title=`get_title_by_res "$res"`
+assert_equal "首相官邸ホームページ" "$title"
 
 echo test get_title_by_res
 res=`wget -q -O - https://www.city.funabashi.lg.jp/jigyou/shoukou/002/corona-jigyosha.html`
 title=`get_title_by_res "$res"`
-title_expect_result="新型コロナウィルス感染症に関する中小企業者（農林漁業者を含む）・労働者への支援｜船橋市公式ホームページ"
-if [ "$actual" = "$expect" ]; then
-	test_passed
-else
-	test_failed "$expect" "$actual"
-fi
+assert_equal "新型コロナウィルス感染症に関する中小企業者（農林漁業者を含む）・労働者への支援｜船橋市公式ホームページ" "$title"
 
 echo test get_title_by_res
 res=`wget -q -O - https://www.pref.oita.jp/soshiki/14040/sodanmadoguti1.html`
-actual=`get_title_by_res "$res"`
-expect="新型コロナウイルスの流行に伴う経営・金融相談窓口の開設について - 大分県ホームページ"
-if [ "$actual" = "$expect" ]; then
-	test_passed
-else
-	test_failed "$expect" "$actual"
-fi
+title=`get_title_by_res "$res"`
+assert_equal "新型コロナウイルスの流行に伴う経営・金融相談窓口の開設について - 大分県ホームページ" "$title"

--- a/test/wget_test.sh
+++ b/test/wget_test.sh
@@ -10,5 +10,6 @@ actual=`get_target_urls data/test.csv`
 assert_equal "http://www.kantei.go.jp https://www.cao.go.jp http://www.bousai.go.jp https://www.mhlw.go.jp https://www.meti.go.jp" "$actual"
 
 echo test get_target_domains
-actual=`get_target_domains $actual`
-assert_equal "www.kantei.go.jp www.cao.go.jp www.bousai.go.jp www.mhlw.go.jp www.meti.go.jp" "$actual"
+urls="https://www.cao.go.jp http://www.bousai.go.jp"
+domains=`get_target_domains $urls`
+assert_equal "www.cao.go.jp www.bousai.go.jp" "$domains"

--- a/test/wget_test.sh
+++ b/test/wget_test.sh
@@ -7,18 +7,8 @@ set -e
 
 echo test get_target_urls
 actual=`get_target_urls data/test.csv`
-expect="http://www.kantei.go.jp https://www.cao.go.jp http://www.bousai.go.jp https://www.mhlw.go.jp https://www.meti.go.jp"
-if [ "$actual" = "$expect" ]; then
-	test_passed
-else
-	test_failed "$expect" "$actual"
-fi
+assert_equal "http://www.kantei.go.jp https://www.cao.go.jp http://www.bousai.go.jp https://www.mhlw.go.jp https://www.meti.go.jp" "$actual"
 
 echo test get_target_domains
 actual=`get_target_domains $actual`
-expect="www.kantei.go.jp www.cao.go.jp www.bousai.go.jp www.mhlw.go.jp www.meti.go.jp"
-if [ "$actual" = "$expect" ]; then
-	test_passed
-else
-	test_failed "$expect" "$actual"
-fi
+assert_equal "www.kantei.go.jp www.cao.go.jp www.bousai.go.jp www.mhlw.go.jp www.meti.go.jp" "$actual"


### PR DESCRIPTION
テストの値チェックとそれによる出力処理の記述で重複ヶ所が多かったため、assert っぽい関数を helper.sh に定義し、それらの関数を使ってテスト結果をチェックするようにしました。