### PR TITLE
url-helper_test において、assert_equal に渡す変数をダブルクォーテーションで囲む

### DIFF
--- a/lib/url-helper.sh
+++ b/lib/url-helper.sh
@@ -14,7 +14,7 @@ get_domain_by_url() {
 get_orgname_by_url() {
     url=$1
     domain=`get_domain_by_url $url`
-    govname=`grep $domain --include="*.csv" ./data/*|cut -d',' -f 1|cut -d':' -f 2`
+    govname=`grep "$domain" ./data/*.csv | head -1 | cut -d',' -f 1 | cut -d':' -f 2`
     echo $govname
     return 0
 }

--- a/lib/url-helper.sh
+++ b/lib/url-helper.sh
@@ -9,7 +9,9 @@ get_domain_by_url() {
 }
 
 
-get_govname_by_url() {
+# URL から団体名を取得
+#   /data/*.csv からドメインに紐づく名前定義を引っ張ってくる
+get_orgname_by_url() {
     url=$1
     domain=`get_domain_by_url $url`
     govname=`grep $domain --include="*.csv" ./data/*|cut -d',' -f 1|cut -d':' -f 2`

--- a/slack-bot/url-map.sh
+++ b/slack-bot/url-map.sh
@@ -97,7 +97,7 @@ send_message() {
 		return 0
 	fi
 	title=`get_title_by_url ${url}`
-	govname=`get_govname_by_url ${url}`
+	govname=`get_orgname_by_url ${url}`
 	echo $govname
 	# unixtime
 	timestamp=`date '+%s'`

--- a/slack-bot/url-reduce.sh
+++ b/slack-bot/url-reduce.sh
@@ -15,7 +15,7 @@ for key in $keys; do
 	bool=`echo $result| cut -d',' -f 4`
 	if [ $bool = "true" ]; then
 		url=`echo $result| cut -d',' -f 1`
-		govname=`get_govname_by_url $url`
+		govname=`get_orgname_by_url $url`
 		# urlからpathを得る
 		path=${url//http:\/\//}
 		path=${path//https:\/\//}

--- a/test/url-helper_test.sh
+++ b/test/url-helper_test.sh
@@ -11,7 +11,7 @@ expect="www.kantei.go.jp"
 assert_equal "$expect" "$actual"
 
 
-echo test get_govname_by_url
-actual=`get_govname_by_url https://www.mhlw.go.jp`
+echo test get_orgname_by_url
+actual=`get_orgname_by_url https://www.mhlw.go.jp`
 expect="厚生労働省"
 assert_equal "$expect" "$actual"

--- a/test/url-helper_test.sh
+++ b/test/url-helper_test.sh
@@ -8,10 +8,10 @@ set -e
 echo test get_domain_by_url
 actual=`get_domain_by_url http://www.kantei.go.jp`
 expect="www.kantei.go.jp"
-assert_equal $expect $actual
+assert_equal "$expect" "$actual"
 
 
 echo test get_govname_by_url
 actual=`get_govname_by_url https://www.mhlw.go.jp`
 expect="厚生労働省"
-assert_equal $expect $actual
+assert_equal "$expect" "$actual"


### PR DESCRIPTION
`assert_equal $expect $actual` のような関数呼び出しの書き方だと、変数値にスペースが含まれる場合に引数が分断して解釈されてしまいます。

そのような挙動を防ぐために `assert_equal "$expect" "$actual"` このように変数をダブルクォーテーションで囲みました。

詳細説明は https://github.com/arakawatomonori/covid19-surveyor/pull/119#pullrequestreview-395990585 ここにも書き残してあります。