### PR TITLE
投票時メッセージ内のチャンネル名表示ではリンクタグを使わない

### DIFF
--- a/slack-bot/url-bool-map.sh
+++ b/slack-bot/url-bool-map.sh
@@ -71,7 +71,7 @@ send_message() {
 
 ※回答に困ったとき
 • <https://github.com/arakawatomonori/covid19-surveyor/wiki/%E3%83%87%E3%83%BC%E3%82%BF%E6%95%B4%E7%90%86%E3%83%9C%E3%83%83%E3%83%88%E3%81%B8%E3%81%AE%E5%9B%9E%E7%AD%94%E6%96%B9%E9%87%9D-FAQ|FAQ> に、回答時の FAQ をまとめてあります。
-• FAQ 等を見ても分からない場合は Slack の <https://app.slack.com/client/T02FMV4EB/C011U5YG8S3|#covid19-survey-qa> にご質問ください。
+• FAQ 等を見ても分からない場合は Slack の #covid19-survey-qa にご質問ください。
 "
                         }
                 },

--- a/slack-bot/url-vote-map.sh
+++ b/slack-bot/url-vote-map.sh
@@ -81,7 +81,7 @@ send_message() {
 
 ※回答に困ったとき
 • <https://github.com/arakawatomonori/covid19-surveyor/wiki/%E3%83%87%E3%83%BC%E3%82%BF%E6%95%B4%E7%90%86%E3%83%9C%E3%83%83%E3%83%88%E3%81%B8%E3%81%AE%E5%9B%9E%E7%AD%94%E6%96%B9%E9%87%9D-FAQ|FAQ> に、回答時の FAQ をまとめてあります。
-• FAQ 等を見ても分からない場合は Slack の <https://app.slack.com/client/T02FMV4EB/C011U5YG8S3|#covid19-survey-qa> にご質問ください。
+• FAQ 等を見ても分からない場合は Slack の #covid19-survey-qa にご質問ください。
 "
             }
         },


### PR DESCRIPTION
・チャンネル名はリンクタグを使うまでもなく自動的にリンクになるはず
・Slackアプリからチャンネル名リンクを踏むとブラウザが開いてしまうので不便だった