### PR TITLE
JavaScriptをindex.htmlからwww-data/index.jsに切り出した

### DIFF
--- a/crawler/publish.sh
+++ b/crawler/publish.sh
@@ -292,42 +292,7 @@ head=`cat <<EOM
             word-break: break-all;
         }
     </style>
-    <script>
-        function quotemeta(string) {
-            return string.replace(/(\W)/, "$1");
-        }
-
-        function isearch(pattern) {
-            var regex = new RegExp(quotemeta(pattern), "i");
-            var spans = document.getElementsByTagName('li');
-            var length = spans.length;
-            var applis = 0;
-            for (var i = 0; i < length; i++) {
-                var e = spans[i];
-                if (e.className === "card") {
-                    if (e.innerHTML.match(regex)) {
-                        e.style.display = "list-item";
-                        applis += 1;
-                    } else {
-                        e.style.display = "none";
-                    }
-                }
-            }
-            const elem = document.getElementById("applicable-number");
-            elem.textContent = '該当件数:' + applis + '件';
-        }
-
-        function applicable() {
-            const ulElement = document.getElementById("cards");
-            const childElementCount = ulElement.childElementCount;
-            const elem = document.getElementById("applicable-number");
-            elem.textContent = '該当件数:' + childElementCount + '件';
-        }
-
-        window.onload = function () {
-            applicable()
-        }
-    </script>
+    <script async src="./index.js"></script>
 </head>
 EOM
 `

--- a/www-data/index.js
+++ b/www-data/index.js
@@ -1,0 +1,34 @@
+function quotemeta(string) {
+    return string.replace(/(\W)/, "$1");
+}
+
+function isearch(pattern) {
+    var regex = new RegExp(quotemeta(pattern), "i");
+    var spans = document.getElementsByTagName('li');
+    var length = spans.length;
+    var applis = 0;
+    for (var i = 0; i < length; i++) {
+        var e = spans[i];
+        if (e.className === "card") {
+            if (e.innerHTML.match(regex)) {
+                e.style.display = "list-item";
+                applis += 1;
+            } else {
+                e.style.display = "none";
+            }
+        }
+    }
+    const elem = document.getElementById("applicable-number");
+    elem.textContent = '該当件数:' + applis + '件';
+}
+
+function applicable() {
+    const ulElement = document.getElementById("cards");
+    const childElementCount = ulElement.childElementCount;
+    const elem = document.getElementById("applicable-number");
+    elem.textContent = '該当件数:' + childElementCount + '件';
+}
+
+window.onload = function () {
+    applicable()
+}


### PR DESCRIPTION
## 修正内容

`crawler/publish.sh` が生成する `index.html` 内のscriptタグにインラインで書かれているjsを別のファイルに切り出しました。
今後もしjavascriptをビルドする仕組みを入れる場合にも、この構成の方がやりやすいはずです。



## 背景

webサイト上の検索機能に手を加えようと思った #156 のですが、
`crawler/publish.sh` の中にhtmlとjavascriptがインラインで書かれていて難しかった。


例えばこういうのを書くと

```js
  searchString
    .split(/\s+/)
    .map(function() {
```

こう、改行が連結されてsyntax errorになってしまう

[![Screenshot from Gyazo](https://gyazo.com/3c0e47a554f0fc2412b75b78eaa02b52/raw)](https://gyazo.com/3c0e47a554f0fc2412b75b78eaa02b52)

