### PR TITLE
innerHTMLではなくinnerTextを検索する

### DIFF
--- a/www-data/index.js
+++ b/www-data/index.js
@@ -10,7 +10,7 @@ function isearch(pattern) {
     for (var i = 0; i < length; i++) {
         var e = spans[i];
         if (e.className === "card") {
-            if (e.innerHTML.match(regex)) {
+            if (regex.test(e.innerText)) {
                 e.style.display = "list-item";
                 applis += 1;
             } else {


### PR DESCRIPTION
## 現状

`<li>` 要素のinnerHTMLに対して検索している。

しかしinnerHTMLにはHTMLタグが含まれる

[![Screenshot from Gyazo](https://gyazo.com/2621a1ed344fb093968cd06299f57312/raw)](https://gyazo.com/2621a1ed344fb093968cd06299f57312)

そのため、divとかaとかで検索すると全件がヒットしてしまう
[![Screenshot from Gyazo](https://gyazo.com/227623abf377df6068c35c82a9921fba/raw)](https://gyazo.com/227623abf377df6068c35c82a9921fba)

## 修正

innerTextで検索するようにしました

[![Screenshot from Gyazo](https://gyazo.com/5845a0776ccf9cba7a07933e07ce1e4b/raw)](https://gyazo.com/5845a0776ccf9cba7a07933e07ce1e4b)