### PR TITLE
url-bool-reduce: description の改行を削る

### DIFF
--- a/lib/string-helper.sh
+++ b/lib/string-helper.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+source .env
+
+
+# 改行とコンマの除去
+# - \n は read line の時点で削られる.
+# - \r は sed で明示的に削る.
+# - コンマも sed で削るが、コンマ前後の文字列が繋がるのは良くないのでスペースに置換.
+remove_newline_and_comma() {
+    while read line
+    do
+        echo -n $(echo $line | sed -z 's/\r//g' | sed -z 's/,/ /g')
+    done
+    echo ""
+}
+
+
+# *.sh が直接実行されたら exit 0 する
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    exit 0
+fi

--- a/slack-bot/url-bool-reduce.sh
+++ b/slack-bot/url-bool-reduce.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
 set -e
 
+#
+# Summary
+#   投票結果を元に CSV 形式の文字列を標準出力に出力
+#
+# Detail
+#   ・Redis の "vscovid-crawler:result-*" を元に URL を抽出
+#   ・抽出した URL を全 wget し、結果を CSV 形式で標準出力に出力
+#
+# Caution
+#   wget が URL 件数分走るので負荷に注意
+#
+
+# 依存lib
 . ./lib/url-helper.sh
 
+# 改行除去関数（極端に文字列幅が削られた？という報告もあるので挙動は運用しながら様子見）
 remove_newline_and_comma() {
     result=$(echo $1|sed -z 's/\r//g'|sed -z 's/\n//g'|sed -z 's/,//g')
     echo $result
@@ -18,6 +32,7 @@ get_row_by_url() {
     fi
     title=$(get_title_by_res "$res")
     desc=$(get_desc_by_res "$res")
+    desc=$(remove_newline_and_comma "$desc")
     echo $orgname,$prefname,$url,$title,$desc
 }
 

--- a/slack-bot/url-bool-reduce.sh
+++ b/slack-bot/url-bool-reduce.sh
@@ -15,12 +15,7 @@ set -e
 
 # 依存lib
 . ./lib/url-helper.sh
-
-# 改行除去関数（極端に文字列幅が削られた？という報告もあるので挙動は運用しながら様子見）
-remove_newline_and_comma() {
-    result=$(echo $1|sed -z 's/\r//g'|sed -z 's/\n//g'|sed -z 's/,//g')
-    echo $result
-}
+. ./lib/string-helper.sh
 
 get_row_by_url() {
     url=$1
@@ -31,8 +26,7 @@ get_row_by_url() {
         return 1
     fi
     title=$(get_title_by_res "$res")
-    desc=$(get_desc_by_res "$res")
-    desc=$(remove_newline_and_comma "$desc")
+    desc=$(get_desc_by_res "$res" | remove_newline_and_comma)
     echo $orgname,$prefname,$url,$title,$desc
 }
 

--- a/test/string-helper_test.sh
+++ b/test/string-helper_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+. ./lib/test-helper.sh
+. ./lib/string-helper.sh
+
+echo test remove_newline_and_comma
+result=$(echo -e "abc def
+GHI,A,B,C" | remove_newline_and_comma)
+assert_equal "abc defGHI A B C" "$result"


### PR DESCRIPTION
url-bool-reduce.sh が reduce.csv を構築する構造になっているが、今は description に改行が混じることがある。その改行が他処理に悪影響を与えることがあるため、description からは改行を削る。