### PR TITLE
ヘッダーにボランティア参加方法を追記

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ www-data/*.com
 www-data/*.net
 www-data/*.tv
 www-data/*.jp
-www-data/wget-log*
 www-data/map/
+www-data/wget-log*
 www-data/index.html
 www-data/index.json
 *.jp

--- a/map-client/src/App.vue
+++ b/map-client/src/App.vue
@@ -12,6 +12,12 @@
         <a href="https://www.code4japan.org/">Code for Japan</a>
         のボランティアたちがまとめたウェブサイトです
       </p>
+      <p>
+        情報収集整理ボランティアへの参加は <a href="https://cfjslackin.herokuapp.com/">こちらのSlack</a> からできます
+      </p>
+      <p>
+        システム開発ボランティアへの参加は <a href="https://github.com/arakawatomonori/covid19-surveyor">こちらのGithub</a> からできます
+      </p>
     </header>
 
     <main class="main">

--- a/map-client/src/App.vue
+++ b/map-client/src/App.vue
@@ -145,6 +145,10 @@ export default {
   line-height: 1.2;
 }
 
+.site-header .p {
+  color: white;
+}
+
 .main {
   margin: 32px auto;
   width: 100%;


### PR DESCRIPTION
- これまでのトップページにあったボランティア参加方法をmap-clientでも出したい
- Slackに関しては、 #general で #vscovid19 チャンネルへの誘導を定期的にしているのでチャンネル名は明記しない