### PR TITLE
地図選択フロントエンドの「〜のサイトへ」にhrefを指定

### DIFF
--- a/map-client/src/App.vue
+++ b/map-client/src/App.vue
@@ -65,7 +65,10 @@
                 {{ item.description }}
               </p>
               <p class="action-area">
-                <a class="button is-primary is-rounded">{{ item.orgname }}のサイトへ</a>
+                <a
+                  class="button is-primary is-rounded"
+                  :href="item.url"
+                >{{ item.orgname }}のサイトへ</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
リンクが切れていたので追加しました。