### PR TITLE
feat: build map-client for staging

### DIFF
--- a/map-client/now.json
+++ b/map-client/now.json
@@ -1,0 +1,19 @@
+{
+    "name": "covid19-surveyor",
+    "version": 2,
+    "builds": [
+      {
+        "src": "package.json",
+        "use": "@now/static-build",
+        "config": { "distDir": "../www-data/map" }
+      }
+    ],
+    "routes": [
+      {
+        "src": "/(js|css|img)/.*",
+        "headers": { "cache-control": "max-age=31536000, immutable" }
+      },
+      { "handle": "filesystem" },
+      { "src": ".*", "dest": "/" }
+    ]
+  }

--- a/map-client/package.json
+++ b/map-client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
+    "build:stg": "vue-cli-service build --mode development",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },

--- a/map-client/package.json
+++ b/map-client/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build:stg": "vue-cli-service build --mode development",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "now-build": "vue-cli-service build --mode development"
   },
   "dependencies": {
     "@vue/cli-plugin-babel": "4.1.1",


### PR DESCRIPTION
- フロントエンドのステージング環境をつくりました
  - こんな感じでPR毎にユニークなページが割り当てます
  - フォーク先で再現: https://github.com/yokinist/covid19-surveyor/pull/1
- dataはモックのものを参照しています

### 備考
- もし良さそうだったらGitHubの紐付けを権限がないので別途していただく必要があります
- その場合はプロジェクト用にチームをつくってinviteさせていただきます🙏