### PR TITLE
survey-bot の FAQ 案内の URL を変更

### DIFF
--- a/slack-bot/url-bool-map.sh
+++ b/slack-bot/url-bool-map.sh
@@ -70,7 +70,7 @@ send_message() {
 ※このURLがトップページやリンク集の場合は「いいえ」と答えてください
 
 ※回答に困ったとき
-• <https://github.com/arakawatomonori/covid19-surveyor/wiki/%E3%83%87%E3%83%BC%E3%82%BF%E6%95%B4%E7%90%86%E3%83%9C%E3%83%83%E3%83%88%E3%81%B8%E3%81%AE%E5%9B%9E%E7%AD%94%E6%96%B9%E9%87%9D-FAQ|FAQ> に、回答時の FAQ をまとめてあります。
+• <https://github.com/arakawatomonori/covid19-surveyor/wiki|Wiki> 内に回答時の FAQ をまとめてあります。
 • FAQ 等を見ても分からない場合は Slack の #covid19-survey-qa にご質問ください。
 "
                         }

--- a/slack-bot/url-vote-map.sh
+++ b/slack-bot/url-vote-map.sh
@@ -80,7 +80,7 @@ send_message() {
 ※このURLがトップページやリンク集の場合は「いいえ」と答えてください
 
 ※回答に困ったとき
-• <https://github.com/arakawatomonori/covid19-surveyor/wiki/%E3%83%87%E3%83%BC%E3%82%BF%E6%95%B4%E7%90%86%E3%83%9C%E3%83%83%E3%83%88%E3%81%B8%E3%81%AE%E5%9B%9E%E7%AD%94%E6%96%B9%E9%87%9D-FAQ|FAQ> に、回答時の FAQ をまとめてあります。
+• <https://github.com/arakawatomonori/covid19-surveyor/wiki|Wiki> 内に回答時の FAQ をまとめてあります。
 • FAQ 等を見ても分からない場合は Slack の #covid19-survey-qa にご質問ください。
 "
             }


### PR DESCRIPTION
・将来的に Wiki 内の各種ページの URL が変更されてもボットメッセージを変更しなくても良いように、リンク先は Wiki トップへのリンクにした

※ Wiki 内の FAQ ページの URL が汚過ぎたので [survey-faq](https://github.com/arakawatomonori/covid19-surveyor/wiki/Survey-FAQ) という URL に変更済み

