### PR TITLE
フロント表示の性能改善

### DIFF
--- a/map-client/package.json
+++ b/map-client/package.json
@@ -10,8 +10,9 @@
   },
   "dependencies": {
     "@vue/cli-plugin-babel": "4.1.1",
-    "vue": "^2.6.11",
-    "japan-map-js": "chrome-cgi/japan-map-js#fix-pointer-pos"
+    "debounce": "^1.2.0",
+    "japan-map-js": "chrome-cgi/japan-map-js#fix-pointer-pos",
+    "vue": "^2.6.11"
   },
   "devDependencies": {
     "@vue/cli-plugin-eslint": "4.1.1",

--- a/map-client/public/index.html
+++ b/map-client/public/index.html
@@ -14,7 +14,7 @@
     <title>新型コロナウイルス（COVID-19）各自治体の経済支援制度まとめ（地域検索）</title>
     <!-- <link rel="icon" href="<%= BASE_URL %>favicon.ico"> -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.2/css/bulma.min.css">
-    <script defer src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   </head>
   <body>
     <noscript>

--- a/map-client/src/App.vue
+++ b/map-client/src/App.vue
@@ -115,7 +115,7 @@
                 <a class="button is-primary is-rounded" :href="item.url" target="_blank" rel="noopener">
                   <span>{{ item.orgname }}のサイトへ</span>
                   <span class="icon is-small">
-                    <i class="fas fa-external-link-alt" aria-label="外部サイトに移動します"></i>
+                    <i class="fa fa-external-link" aria-label="外部サイトに移動します"></i>
                   </span>
                 </a>
               </div>

--- a/map-client/src/App.vue
+++ b/map-client/src/App.vue
@@ -97,10 +97,10 @@
             </div>
             <div class="content">
               <p class="subtitle is-6">
-                {{ item.description }}
+                {{ item.shortDesc }}
               </p>
-              <div class="action-area">
-                <div class="share-buttons">
+              <div class="action-area is-clearfix">
+                <div class="share-buttons is-pulled-left">
                   <a class="share-button" :href="shareLineURL(item)" target="_blank" rel="noopener noreferrer">
                     <img src="line.svg">
                   </a>
@@ -112,7 +112,7 @@
                   </a>
                 </div>
 
-                <a class="button is-primary is-rounded" :href="item.url" target="_blank" rel="noopener">
+                <a class="jump-button button is-primary is-rounded is-pulled-right" :href="item.url" target="_blank" rel="noopener">
                   <span>{{ item.orgname }}のサイトへ</span>
                   <span class="icon is-small">
                     <i class="fa fa-external-link" aria-label="外部サイトに移動します"></i>
@@ -129,6 +129,8 @@
 
 <script>
 import jpmap from 'japan-map-js'
+
+const MAX_DESC_LENGTH = 200
 
 export default {
   name: "App",
@@ -180,7 +182,10 @@ export default {
       fetch(process.env.VUE_APP_JSON_PATH)
         .then(resp => resp.json())
         .then(json => {
-          this.items = json
+          this.items = json.map(item => ({
+            ...item,
+            shortDesc: this.clipDesc(item.description)
+          }))
         })
     },
     setupMap() {
@@ -219,6 +224,12 @@ export default {
     },
     shareFBURL(item) {
       return `https://www.facebook.com/sharer.php?u=${item.url}`
+    },
+    clipDesc(desc) {
+      let clipped = desc.replace(/&\w+;/g, ' ')
+      return clipped.length > MAX_DESC_LENGTH
+        ? clipped.slice(0, MAX_DESC_LENGTH) + '…'
+        : clipped
     }
   }
 }
@@ -230,32 +241,25 @@ export default {
   margin: 0 auto;
 }
 
-.site-header > .site-description {
-  color: white;
-}
-
-.site-header > .site-description > .description-link  {
-  text-decoration: underline;
-  color: white;
-  padding: 0 4px;
-}
-
-.site-header > .site-description > .description-link:hover {
-  text-decoration: none;
-}
-
 .site-header {
   background: #ac0027;
   padding: 24px;
-}
-
-.site-title {
   color: white;
-  line-height: 1.2;
-}
 
-.site-header .p {
-  color: white;
+  .site-title {
+    color: white;
+    line-height: 1.2;
+  }
+
+  .description-link {
+    text-decoration: underline;
+    color: white;
+    padding: 0 4px;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
 }
 
 .main {
@@ -270,10 +274,10 @@ export default {
 
 .info-area {
   margin: 32px 0;
-}
 
-.cb-national {
-  margin-bottom: 16px;
+  .cb-national {
+    margin-bottom: 16px;
+  }
 }
 
 .card {
@@ -286,15 +290,13 @@ export default {
 }
 
 .card-title {
-  display: flex;
-  align-items: baseline;
   font-size: 1.5rem;
   line-height: 1.5;
 }
 
 .card-content {
   .tag {
-    background: transparent;
+    background: white;
     color: #3273dc;
     border: solid 1px #3273dc;
     font-weight: bold;
@@ -308,20 +310,25 @@ export default {
 }
 
 .action-area {
-  margin-top: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
+  margin-top: 16px;
 
-.share-button {
-  display: inline-block;
-  width: 40px;
-  height: 40px;
-  margin-right: 12px;
+  .share-buttons {
+    margin-top: 8px;
+  }
 
-  img:hover {
-    opacity: 0.5;
+  .share-button {
+    display: inline-block;
+    width: 40px;
+    height: 40px;
+    margin-right: 12px;
+
+    img:hover {
+      opacity: 0.5;
+    }
+  }
+
+  .jump-button {
+    margin-top: 8px;
   }
 }
 
@@ -338,9 +345,10 @@ export default {
 
 .search-area {
   margin-bottom: 16px;
-}
-.search-box {
-  margin: 8px 0 8px 1rem;
+
+  .search-box {
+    margin: 8px 0 8px 1rem;
+  }
 }
 
 label {
@@ -365,7 +373,6 @@ label {
 
   .share-button {
     margin-right: 8px;
-    margin-bottom: 8px;
   }
 }
 </style>

--- a/map-client/src/App.vue
+++ b/map-client/src/App.vue
@@ -158,11 +158,11 @@ export default {
       if (this.isSearchTypeString) {
         return this.searchString
           ? `キーワード: ${this.searchString}`
-          : '検索結果'
+          : '全ての経済支援制度'
       }
       return this.selectedPref
         ? `地域: ${this.selectedPref}`
-        : '検索結果'
+        : '全ての経済支援制度'
     },
     isSearchTypeString() {
       return this.searchType === 'string'

--- a/map-client/src/App.vue
+++ b/map-client/src/App.vue
@@ -144,17 +144,15 @@ export default {
   },
   computed: {
     filteredItems() {
-      return this.items.filter(i => {
-        if (this.isSearchTypeString) {
-          return !this.searchString || this.isMatchPattern(i)
-        } else {
-          return !this.selectedPref || (
-            this.selectedPref === i.orgname ||
-            this.selectedPref === i.prefname ||
-            (this.includesNationalOffers && '省庁'.includes(i.orgname.slice(-1)))
-          )
-        }
-      })
+      if (this.isSearchTypeString) {
+        return this.searchString
+          ? this.items.filter(i => this.isMatchPattern(i))
+          : this.items
+      } else {
+        return this.selectedPref
+          ? this.items.filter(i => this.isSelectedPref(i))
+          : this.items
+      }
     },
     resultTitle() {
       if (this.isSearchTypeString) {
@@ -203,6 +201,11 @@ export default {
     isMatchPattern(item) {
       return (item.title + item.orgname + item.prefname + item.description)
         .match(this.searchString)
+    },
+    isSelectedPref(item) {
+      return this.selectedPref === item.orgname ||
+        this.selectedPref === item.prefname ||
+        (this.includesNationalOffers && '省庁'.includes(item.orgname.slice(-1)))
     },
     changedSearchType() {
       this.selectedPref = ''

--- a/map-client/src/App.vue
+++ b/map-client/src/App.vue
@@ -225,14 +225,12 @@ export default {
       return `https://www.facebook.com/sharer.php?u=${item.url}`
     },
     clipDesc(desc) {
-      let clipped = desc.replace(/&\w+;/g, ' ')
+      const clipped = desc.replace(/&\w+;/g, ' ')
       return clipped.length > MAX_DESC_LENGTH
         ? clipped.slice(0, MAX_DESC_LENGTH) + '…'
         : clipped
     },
     updateFilteredItems() {
-      if (this.loadingID) clearTimeout(this.loadingID)
-
       this.loadingID = setTimeout(() => {
         if (this.isSearchTypeString) {
           this.filteredItems = this.searchString


### PR DESCRIPTION
closes #193, #162
Preview: https://covid19-surveyor-lx8en99md.now.sh/

該当件数が多い場合に表示に時間がかかっていたのを以下で改善しました
- JS の function call が発生していたアイコン用ライブラリ（Font Awesome v5）を CSS オンリーの v4 に変更
- 不要な CSS の整理
- 表示する description が長すぎる場合途中で切り取る
- 検索欄に入力確定遅延（debounce）を導入

また、結果一覧が更新中であることがユーザーに分かるようにスピナー表示を追加しました。
