### PR TITLE
URL 格納テキストファイル関連の整理

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 **/.git
 **/tmp
-/result.txt
+/results.txt
 /www-data/

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,13 @@ ifeq ($(ENV),production)
 else
 	./crawler/wget.sh data/test.csv
 endif
-	# tmp/urls.txt内の全URLをwww-data以下にミラーリングする
-	# tmp/urls.txtは「経済支援制度ですか？」に「はい」と答えられたURLのみ
+	# TODO:
+	#   tmp/urls.txt は aggregate.sh の準成果物であるはずだが、
+	#   コマンド実行の順序は wget, grep, aggregate であるため、wget が tmp/urls.txt に依存する構造は破綻している.
+	#   ここの処理内容については要改修と思われる.
+	#
+	# tmp/urls.txt 内の全URLを www-data 以下にミラーリングする
+	# tmp/urls.txt は「経済支援制度ですか？」に「はい」と答えられた URL のみ (TODO: このコメントはおそらく間違っている. 要修正検討.)
 	cd www-data
 	cat ../tmp/urls.txt |xargs -I{} wget --force-directories --no-check-certificate {}
 	cd -
@@ -52,12 +57,13 @@ tmp/grep_コロナ.txt.tmp: remove-large-files
 	./crawler/grep.sh
 
 # grep結果を集計する
-# 複数のキーワードでgrepしているので重複があったりするのをuniqする
-# tmp/results.txt, tmp/urls.txt を生成する
+#   複数のキーワードで grep しているので重複があったりするのを uniq し、URL の MD5 ハッシュも求める
+#     成果物: data/urls-md5.csv, tmp/urls.txt を生成する
+#     (TODO: tmp/urls.txt の利用用途が wget の入力値となっているが、これはコマンドの依存関係を破綻させているので、要改修検討)
 .PHONY: aggregate
-aggregate: tmp/results.txt
+aggregate: data/urls-md5.csv
 
-tmp/results.txt: grep
+data/urls-md5.csv: grep
 	./crawler/aggregate.sh
 
 # www-data/index.html, www-data/index.jsonを生成する

--- a/auto-ml/url-vote-reduce-for-auto-ml.sh
+++ b/auto-ml/url-vote-reduce-for-auto-ml.sh
@@ -8,7 +8,7 @@ set -e
 
 get_url_by_md5() {
     md5=$1
-    url=$(grep "$md5" ./urls-md5.csv | head -1 | cut -d',' -f 2)
+    url=$(grep "$md5" ./data/urls-md5.csv | head -1 | cut -d',' -f 2)
     echo $url
 }
 

--- a/crawler/aggregate.sh
+++ b/crawler/aggregate.sh
@@ -2,8 +2,23 @@
 set -e
 
 ###
-### About
-### grep.shで./tmpに収集した情報を結合し、ソートし、重複を取り除くスクリプト
+### About:
+###   grep.sh で ./tmp に収集した情報を結合し、ソートし、重複を取り除くスクリプト
+###
+### Input:
+###   tmp/grep_コロナ_*.txt.tmp
+###
+### Output:
+###   data/urls-md5.csv
+###
+### Secondary output:
+###   ※ 本来はこれを正式な成果物とみなすべきではない.
+###      wget がこのファイルに依存しているようだが、コマンド実行順からすると依存関係が破綻している.
+###   tmp/urls.txt
+###
+### Temporary:
+###   以下のファイルは aggregate.sh 内でしか用いられない一時ファイルであるため、正式な成果物とはみなさい.
+###   - tmp/results.txt
 ###
 ### Dependency
 ### - make wget
@@ -21,7 +36,7 @@ set -e
 # 重複を取り除く
 cat ./tmp/grep_コロナ_*.txt.tmp | sort | uniq > ./tmp/results.txt
 
-# result.txtからURLのみを抜き出す
+# tmp/results.txt から URL のみを抜き出す
 urls=$(cat ./tmp/results.txt | cut -d':' -f 1 | sed -z 's/\.\/www-data\///g')
 
 echo "" > ./tmp/urls.txt
@@ -34,7 +49,7 @@ done
 # sortしてuniqする
 sort < ./tmp/urls.txt | uniq > ./tmp/urls-uniq.txt
 
-echo "" > ./urls-md5.csv
+echo "" > ./data/urls-md5.csv
 
 for domain_and_path in `cat ./tmp/urls-uniq.txt`; do
     # domain=example.com
@@ -51,5 +66,5 @@ for domain_and_path in `cat ./tmp/urls-uniq.txt`; do
     # url=https://example.com/foo/bar.html
     url="$schema//$domain/$path"
     md5=`get_md5_by_url $url`
-    echo "$md5,$url" >> ./urls-md5.csv
+    echo "$md5,$url" >> ./data/urls-md5.csv
 done

--- a/slack-bot/url-bool-queue.sh
+++ b/slack-bot/url-bool-queue.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# urls.txtの内容をredisのqueueとして投入する
+# tmp/urls-uniq.txt の内容をredisのqueueとして投入する
 # すでに投入済みの場合はスキップする
 
 . ./lib/redis-helper.sh


### PR DESCRIPTION
## Summary
- ファイルパスの一元化。
- 各種の矛盾箇所を解消。
- コメントの修正・加筆等により暗黙知を減らし、将来修正すべき点も洗い出す。

## Related files
- tmp/results.txt (result.txt)
- data/urls-md5.csv
- tmp/urls.txt
- tmp/urls-uniq.txt

## Details
- 処理内容とコメントが食い違っている箇所について、コメント部を修正。
- 当プロジェクト内に result.txt というファイルは一切存在せず、実際のファイル名は result**s**.txt なので、各箇所の result.txt 表記を全て result**s**.txt に置き換え。
- urls-md5.csv のファイルパスがリポジトリ直下と data 配下とでバラつきがあったので data/urls-md5.csv に一元化。
- aggregate.sh の正式な成果物は data/urls-md5.csv のみなので、そのように各種記載や処理を変更。
- 実際には tmp/urls-uniq.txt を読み込んでいるところのコメント記載が urls.txt になっている箇所があったため、コメント記載を修正。

## 今後の検討事項
以下のように、各種テキストファイル内に含まれる URL のような文字列構造の形式はバラバラである。せめてファイル名からそれが推測できるようにファイル名のリネームを検討したい。（別 PR にて。可能であれば。）

- data/urls-md5.csv にはスキーマを含む URL が含まれている。
  - 例: `https://betsukai.jp/faq/index.html`
- tmp/results.txt には ./www-data から始まるファイル名が含まれている。
  - 例: `./www-data/betsukai.jp/faq/index.html`
- tmp/urls.txt にはスキーマを除いた URL が含まれている。
  - 例: `betsukai.jp/faq/index.html`
- tmp/urls-uniq.txt にはスキーマを除いた URL が含まれている。
  - 例: `betsukai.jp/faq/index.html `
