### PR TITLE
make deploy でデプロイが終わるようにしたい

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,8 @@ www-data/search/index.html: data/reduce-vote.csv
 .PHONY: deploy
 deploy:
 	rm -f www-data/map/index.html www-data/map/index.json
+	git checkout master
+	git pull origin master
 	make publish
 ifeq ($(ENV),production)
 	aws cloudfront create-invalidation --distribution-id E2JGL0B7V4XZRW --paths '/*'


### PR DESCRIPTION
#210 の続きです。


本番環境で `git pull origin master` のみでデプロイが終わる場合でも `make deploy` をすることで、pull したレポジトリのバージョンを通知する習慣にしたい。


```
takano32@vscovid-crawler:~$ sudo su - ubuntu
ubuntu@vscovid-crawler:~$ cd vscovid-crawler
ubuntu@vscovid-crawler:~/vscovid-crawler$ git pull origin master
ubuntu@vscovid-crawler:~/vscovid-crawler$ make deploy
```

`git` のコマンドも打たないようにしたい。


```
takano32@vscovid-crawler:~$ sudo su - ubuntu
ubuntu@vscovid-crawler:~$ cd vscovid-crawler
ubuntu@vscovid-crawler:~/vscovid-crawler$ make deploy
```
