### PR TITLE
jq の `-r` オプションを使ってクォーテーションを外す

### DIFF
--- a/cgi/slack-event.sh
+++ b/cgi/slack-event.sh
@@ -9,15 +9,12 @@ set -e
 formdata=`cat`
 echo $event_type > /home/ubuntu/wget/tmp/slack-event.formdata.log
 json=$formdata
-token=`echo $json | jq .token`
-token=${token:1:-1}
-event_type=`echo $json | jq .type`
-event_type=${event_type:1:-1}
+token=`echo $json | jq -r .token`
+event_type=`echo $json | jq -r .type`
 echo $event_type > /home/ubuntu/wget/tmp/slack-event.event-type.log
 
 if [ "$event_type" == "url_verification" ]; then
-    challenge=`echo $json | jq .challenge`
-    challenge=${challenge:1:-1}
+    challenge=`echo $json | jq -r .challenge`
     echo 'Content-type: text/plain'
     echo ''
     echo $challenge

--- a/cgi/slack-interact.sh
+++ b/cgi/slack-interact.sh
@@ -14,27 +14,20 @@ decoded_data=$(urldecode $formdata)
 json=${decoded_data:8:-1}}
 echo $json > /home/ubuntu/vscovid-crawler/tmp/slack-interact.json.log
 
-token=`echo $json | jq .token`
-token=${token:1:-1}
-event_type=`echo $json | jq .type`
-event_type=${event_type:1:-1}
+token=`echo $json | jq -r .token`
+event_type=`echo $json | jq -r .type`
 echo $event_type > /home/ubuntu/vscovid-crawler/tmp/slack-interact.event-type.log
 
 if [ "$event_type" == "block_actions" ]; then
-    channel_id=`echo $json | jq .channel.id`
-    channel_id=${channel_id:1:-1}
-    ts=`echo $json | jq .container.message_ts`
-    ts=${ts:1:-1}
-    user_id=`echo $json | jq .user.id`
-    user_id=${user_id:1:-1}
-    url=`echo $json | jq .message.blocks[2].text.text`
-    url=${url:7:-2}
+    channel_id=`echo $json | jq -r .channel.id`
+    ts=`echo $json | jq -r .container.message_ts`
+    user_id=`echo $json | jq -r .user.id`
+    url=`echo $json | jq -r .message.blocks[2].text.text`
+    url=`echo ${url:6}`
     md5=`get_md5_by_url $url`
     timestamp=`date '+%s'`
-    result=`echo $json | jq .actions[0].value`
-    result=${result:1:-1}
-    action_id=`echo $json | jq .actions[0].action_id`
-    action_id=${action_id:1:-1}
+    result=`echo $json | jq -r .actions[0].value`
+    action_id=`echo $json | jq -r .actions[0].action_id`
     echo $action_id > /home/ubuntu/vscovid-crawler/tmp/slack-interact.action-id.log
     namespace="vscovid-crawler"
     remain=""

--- a/lib/slack-helper.sh
+++ b/lib/slack-helper.sh
@@ -29,8 +29,7 @@ get_channels_id() {
         channels_list=`cat $channels_list_file`
     fi
     # channels_listをslack_channelで絞り込んでchannels_idを得る
-    channels_id=`echo $channels_list | jq '.channels[] | select(.name == "'${channel_name}'")' | jq .id`
-    channels_id=${channels_id:1:-1}
+    channels_id=`echo $channels_list | jq '.channels[] | select(.name == "'${channel_name}'")' | jq -r .id`
     echo $channels_id
     return 0
 }
@@ -67,7 +66,6 @@ open_im() {
     member_id=$1
     im_open=`wget -q -O - --post-data "token=${slack_token}&user=${member_id}" https://slack.com/api/im.open`
     echo $im_open > ./tmp/im_open.json
-    im_id=`echo $im_open | jq .channel.id`
-    im_id=${im_id:1:-1}
+    im_id=`echo $im_open | jq -r .channel.id`
     echo $im_id
 }

--- a/slack-bot/url-bool-map.sh
+++ b/slack-bot/url-bool-map.sh
@@ -136,7 +136,7 @@ main() {
     # テスターのID
     #members_list="xUUL8QC8BUx xU011H85CM0Wx xUUQ99JY5Rx xU011C3YGDABx"
     for member in $members_list; do
-        member_id=${member:1:-1}
+        member_id=`echo $member`
         send_message $member_id
     done
 }

--- a/slack-bot/url-select-target-map.sh
+++ b/slack-bot/url-select-target-map.sh
@@ -144,7 +144,7 @@ main() {
     # テスターのID
     #members_list="xUUL8QC8BUx"
     for member in $members_list; do
-        member_id=${member:1:-1}
+        member_id=`echo $member`
         send_message $member_id
     done
 }

--- a/slack-bot/url-vote-map.sh
+++ b/slack-bot/url-vote-map.sh
@@ -145,7 +145,7 @@ main() {
     # テスターのID
     #members_list="xUUL8QC8BUx xU011H85CM0Wx xUUQ99JY5Rx xU011C3YGDABx"
     for member in $members_list; do
-        member_id=${member:1:-1}
+        member_id=`$member`
         send_message $member_id
     done
 }


### PR DESCRIPTION
`git grep -C 4 jq` でチェックした範囲。

```
$ echo '{"hoge":"fuga"}' | jq .hoge
"fuga"
```


```
$ echo '{"hoge":"fuga"}' | jq -r .hoge
fuga
```

さすがに `${foo:1:-1}` はちょっと。