### PR TITLE
.env 読み取り箇所で .env のエラーチェックを行う

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,5 +14,10 @@ slack_token=xxxxxxxxx
 #     - Post some information such as a Survey ranking into this channel by bot.
 slack_channel=vscovid19
 
+# Developers' Slack channel name
+#   Purpose:
+#     - Notify production version in deployment.
+slack_channel_develop=covid19-surveyor-dev
+
 # Note: For further information, See also Wiki of our project.
 #       https://github.com/arakawatomonori/covid19-surveyor/wiki

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,18 @@
-# working environment
+# Working environment
+# - production  ... For Production
+# - development ... For Developers
+# - test        ... For CircleCI
 environment=development
+
+# Slack API Token
 # https://api.slack.com/apps/A012EC4TAUQ/oauth の OAuth Access Token
 slack_token=xxxxxxxxx
-# slack channel name
+
+# Slack channel name
+#   Purpose:
+#     - Gather users from this channel so as to get cooperation by them with surveys.
+#     - Post some information such as a Survey ranking into this channel by bot.
 slack_channel=vscovid19
+
+# Note: For further information, See also Wiki of our project.
+#       https://github.com/arakawatomonori/covid19-surveyor/wiki

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.env-test
 .ipynb_checkpoints
 web.*
 www-data/www*
@@ -18,3 +19,4 @@ grep_*
 *.log
 tmp/*
 node_modules/
+

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -1,8 +1,8 @@
 env_filename=.env
 
-# テスト時には ENV_ALTERNATIVE_FILENAME により .env ファイル名を差し替える
-if [ "$ENV_ALTERNATIVE_FILENAME" != "" ]; then
-    env_filename="$ENV_ALTERNATIVE_FILENAME"
+# テスト時には ENV_FILENAME により .env ファイル名を差し替える
+if [ "$ENV_FILENAME" != "" ]; then
+    env_filename="$ENV_FILENAME"
 fi
 
 

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -18,7 +18,7 @@ fi
 
 
 # 必要値の存在チェック
-keys=("environment" "slack_token" "slack_channel")
+keys=("environment" "slack_token" "slack_channel" "slack_channel_develop")
 for key in "${keys[@]}"; do
     if [ "${!key}" == "" ]; then
         >&2 echo -e "ENV ERROR: $env_filename parameter '$key' is required. See .env.sample, README, or Wiki of Repository."

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -1,0 +1,27 @@
+env_filename=.env
+
+# テスト時には ENV_ALTERNATIVE_FILENAME により .env ファイル名を差し替える
+if [ "$ENV_ALTERNATIVE_FILENAME" != "" ]; then
+    env_filename="$ENV_ALTERNATIVE_FILENAME"
+fi
+
+
+# .env ファイルの存在チェック
+if [ ! -f "$env_filename" ]; then
+    >&2 echo "ENV ERROR: $env_filename is required. See .env.sample, README, or Wiki of Repository."
+    exit 1
+fi
+
+
+# .env 読み取り
+. "$env_filename"
+
+
+# 必要値の存在チェック
+keys=("environment" "slack_token" "slack_channel")
+for key in "${keys[@]}"; do
+    if [ "${!key}" == "" ]; then
+        >&2 echo -e "ENV ERROR: $env_filename parameter '$key' is required. See .env.sample, README, or Wiki of Repository."
+        exit 1
+    fi
+done

--- a/lib/slack-helper.sh
+++ b/lib/slack-helper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source .env
+. ./lib/env.sh
 ts=`date '+%s'`
 
 # チームのチャンネルID取得

--- a/lib/string-helper.sh
+++ b/lib/string-helper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source .env
+. ./lib/env.sh
 
 
 #

--- a/slack-bot/post-git-commit-log.sh
+++ b/slack-bot/post-git-commit-log.sh
@@ -13,7 +13,7 @@
 
 set -e
 
-source .env
+. ./lib/env.sh
 
 echo -e "environment: $environment"
 

--- a/slack-bot/url-bool-map.sh
+++ b/slack-bot/url-bool-map.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source .env
+. ./lib/env.sh
 
 . ./lib/redis-helper.sh
 . ./lib/slack-helper.sh

--- a/slack-bot/url-bool-rank.sh
+++ b/slack-bot/url-bool-rank.sh
@@ -26,7 +26,7 @@ for line in `cat tmp/rank.txt`; do
     rank=$rank"\r\n<@$user_id> さん、 $count 回"
 done
 
-source .env
+. ./lib/env.sh
 
 . ./slack-bot/url-map.sh
 channels_id=`get_channels_id`

--- a/slack-bot/url-select-target-map.sh
+++ b/slack-bot/url-select-target-map.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source .env
+. ./lib/env.sh
 ts=`date '+%s'`
 
 . ./lib/slack-helper.sh

--- a/slack-bot/url-vote-map.sh
+++ b/slack-bot/url-vote-map.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source .env
+. ./lib/env.sh
 ts=`date '+%s'`
 
 . ./lib/slack-helper.sh

--- a/slack-bot/url-vote-queue.sh
+++ b/slack-bot/url-vote-queue.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
 
+. ./lib/env.sh
+
 . ./lib/url-helper.sh
 . ./lib/redis-helper.sh
 
-source .env
 ts=`date '+%s'`
 
 namespace="vscovid-crawler-vote"

--- a/slack-bot/url-vote-rank.sh
+++ b/slack-bot/url-vote-rank.sh
@@ -13,7 +13,7 @@
 
 set -e
 
-source .env
+. ./lib/env.sh
 
 # 依存lib
 . ./lib/slack-helper.sh

--- a/test/auto-ml-helper_test.sh
+++ b/test/auto-ml-helper_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source .env
+. ./lib/env.sh
 
 . ./lib/test-helper.sh
 . ./lib/auto-ml-helper.sh

--- a/test/env_test.sh
+++ b/test/env_test.sh
@@ -16,9 +16,21 @@ echo "test .env: param existing error case"
 set +e
 echo "environment=test
 slack_token=aaaa
-slack__channel=bbbb" > .env-test # slack_channel パラメーター名をわざと間違える
+slack__channel=bbbb
+slack_channel_develop=cccc" > .env-test # slack_channel パラメーター名をわざと間違える
 msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
 assert_equal "ENV ERROR: .env-test parameter 'slack_channel' is required. See .env.sample, README, or Wiki of Repository." "$msg"
+set -e
+
+
+# .env 内パラメーター slack_channel_develop の存在チェック.
+echo "test .env: param existing error case"
+set +e
+echo "environment=test
+slack_token=aaaa
+slack_channel=bbbb" > .env-test # slack_channel_develop パラメーターをわざと省略する
+msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
+assert_equal "ENV ERROR: .env-test parameter 'slack_channel_develop' is required. See .env.sample, README, or Wiki of Repository." "$msg"
 set -e
 
 
@@ -26,7 +38,8 @@ set -e
 echo "test .env: success case"
 echo "environment=test
 slack_token=aaaa
-slack_channel=bbbb" > .env-test
+slack_channel=bbbb
+slack_channel_develop=cccc" > .env-test
 msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
 assert_equal "" "$msg"
 
@@ -34,3 +47,4 @@ ENV_FILENAME=.env-test source ./lib/env.sh
 assert_equal "test" "$environment"
 assert_equal "aaaa" "$slack_token"
 assert_equal "bbbb" "$slack_channel"
+assert_equal "cccc" "$slack_channel_develop"

--- a/test/env_test.sh
+++ b/test/env_test.sh
@@ -6,7 +6,7 @@
 echo "test .env: existing error case"
 set +e
 rm -f .env-test # わざと消す
-msg=`ENV_ALTERNATIVE_FILENAME=.env-test source ./lib/env.sh 2>&1`
+msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
 assert_equal "ENV ERROR: .env-test is required. See .env.sample, README, or Wiki of Repository." "$msg"
 set -e
 
@@ -17,7 +17,7 @@ set +e
 echo "environment=test
 slack_token=aaaa
 slack__channel=bbbb" > .env-test # slack_channel パラメーター名をわざと間違える
-msg=`ENV_ALTERNATIVE_FILENAME=.env-test source ./lib/env.sh 2>&1`
+msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
 assert_equal "ENV ERROR: .env-test parameter 'slack_channel' is required. See .env.sample, README, or Wiki of Repository." "$msg"
 set -e
 
@@ -27,10 +27,10 @@ echo "test .env: success case"
 echo "environment=test
 slack_token=aaaa
 slack_channel=bbbb" > .env-test
-msg=`ENV_ALTERNATIVE_FILENAME=.env-test source ./lib/env.sh 2>&1`
+msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
 assert_equal "" "$msg"
 
-ENV_ALTERNATIVE_FILENAME=.env-test source ./lib/env.sh
+ENV_FILENAME=.env-test source ./lib/env.sh
 assert_equal "test" "$environment"
 assert_equal "aaaa" "$slack_token"
 assert_equal "bbbb" "$slack_channel"

--- a/test/env_test.sh
+++ b/test/env_test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+. ./lib/test-helper.sh
+
+# .env のファイル存在チェック.
+echo "test .env: existing error case"
+set +e
+rm -f .env-test # わざと消す
+msg=`ENV_ALTERNATIVE_FILENAME=.env-test source ./lib/env.sh 2>&1`
+assert_equal "ENV ERROR: .env-test is required. See .env.sample, README, or Wiki of Repository." "$msg"
+set -e
+
+
+# .env 内パラメーター slack_channel の存在チェック.
+echo "test .env: param existing error case"
+set +e
+echo "environment=test
+slack_token=aaaa
+slack__channel=bbbb" > .env-test # slack_channel パラメーター名をわざと間違える
+msg=`ENV_ALTERNATIVE_FILENAME=.env-test source ./lib/env.sh 2>&1`
+assert_equal "ENV ERROR: .env-test parameter 'slack_channel' is required. See .env.sample, README, or Wiki of Repository." "$msg"
+set -e
+
+
+# .env 内パラメーター正常読み取りチェック
+echo "test .env: success case"
+echo "environment=test
+slack_token=aaaa
+slack_channel=bbbb" > .env-test
+msg=`ENV_ALTERNATIVE_FILENAME=.env-test source ./lib/env.sh 2>&1`
+assert_equal "" "$msg"
+
+ENV_ALTERNATIVE_FILENAME=.env-test source ./lib/env.sh
+assert_equal "test" "$environment"
+assert_equal "aaaa" "$slack_token"
+assert_equal "bbbb" "$slack_channel"

--- a/test/env_test.sh
+++ b/test/env_test.sh
@@ -3,7 +3,7 @@
 . ./lib/test-helper.sh
 
 # .env のファイル存在チェック.
-echo "test .env: existing error case"
+echo "test .env: file existing error case"
 set +e
 rm -f .env-test # わざと消す
 msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
@@ -12,23 +12,28 @@ set -e
 
 
 # .env 内パラメーター slack_channel の存在チェック.
-echo "test .env: param existing error case"
+echo "test .env: param 'slack_channel' existing error case"
 set +e
-echo "environment=test
+cat << EOF > .env-test
+environment=test
 slack_token=aaaa
-slack__channel=bbbb
-slack_channel_develop=cccc" > .env-test # slack_channel パラメーター名をわざと間違える
+slack__channel=bbbb # slack_channel パラメーター名をわざと間違える
+slack_channel_develop=cccc
+EOF
 msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
 assert_equal "ENV ERROR: .env-test parameter 'slack_channel' is required. See .env.sample, README, or Wiki of Repository." "$msg"
 set -e
 
 
 # .env 内パラメーター slack_channel_develop の存在チェック.
-echo "test .env: param existing error case"
+echo "test .env: param 'slack_channel_develop' existing error case"
 set +e
-echo "environment=test
+cat << EOF > .env-test
+environment=test
 slack_token=aaaa
-slack_channel=bbbb" > .env-test # slack_channel_develop パラメーターをわざと省略する
+slack_channel=bbbb
+# slack_channel_develop パラメーターをわざと省略する
+EOF
 msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
 assert_equal "ENV ERROR: .env-test parameter 'slack_channel_develop' is required. See .env.sample, README, or Wiki of Repository." "$msg"
 set -e
@@ -36,10 +41,12 @@ set -e
 
 # .env 内パラメーター正常読み取りチェック
 echo "test .env: success case"
-echo "environment=test
+cat << EOF > .env-test
+environment=test
 slack_token=aaaa
 slack_channel=bbbb
-slack_channel_develop=cccc" > .env-test
+slack_channel_develop=cccc
+EOF
 msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
 assert_equal "" "$msg"
 


### PR DESCRIPTION
Close #230

.env 読み取り時、.env が存在しなかったり .env の中身が足りない場合に .env.sample, README, Wiki あたりを読むことを促すメッセージを表示する。

.env.sample には詳細説明をコメントで付け足した。

## 動作概要
`test/env_test.sh` を見れば概ねの挙動が分かるかと思います。

## Wiki
以下 Wiki ページに .env の簡単な説明を書きました。
https://github.com/arakawatomonori/covid19-surveyor/wiki/%5BDev%5D-.env

## 補足
- Makefile でも同じようなことを行おうとしたが、構文が分からず諦めた。