### PR TITLE
.env の slack_channel_develop は省略可（の対応の続き）

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,6 +14,7 @@ slack_token=xxxxxxxxx
 #     - Post some information such as a Survey ranking into this channel by bot.
 slack_channel=vscovid19
 
+# (Optional)
 # Developers' Slack channel name
 #   Purpose:
 #     - Notify production version in deployment.

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -25,3 +25,9 @@ for key in "${keys[@]}"; do
         exit 1
     fi
 done
+
+
+# slack_channel_develop は Optional だが、利便性を考え、指定がなかった場合のデフォルト値を入れておく
+if [ "$slack_channel_develop" = "" ]; then
+    slack_channel_develop="covid19-surveyor-dev"
+fi

--- a/test/env_test.sh
+++ b/test/env_test.sh
@@ -3,7 +3,7 @@
 . ./lib/test-helper.sh
 
 # .env のファイル存在チェック.
-echo "test .env: file existing error case"
+echo "test .env: file non-existing error case"
 set +e
 rm -f .env-test # わざと消す
 msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
@@ -12,7 +12,7 @@ set -e
 
 
 # .env 内パラメーター slack_channel の存在チェック.
-echo "test .env: param 'slack_channel' existing error case"
+echo "test .env: param 'slack_channel' non-existing error case"
 set +e
 cat << EOF > .env-test
 environment=test
@@ -26,17 +26,18 @@ set -e
 
 
 # .env 内パラメーター slack_channel_develop の存在チェック.
-echo "test .env: param 'slack_channel_develop' existing error case"
-set +e
+echo "test .env: OPTIONAL param 'slack_channel_develop' non-existing success case"
 cat << EOF > .env-test
 environment=test
 slack_token=aaaa
 slack_channel=bbbb
-# slack_channel_develop パラメーターをわざと省略する
+# slack_channel_develop パラメーターをわざと省略する（このパラメーターは Optional なので省略可）
 EOF
 msg=`ENV_FILENAME=.env-test source ./lib/env.sh 2>&1`
-assert_equal "ENV ERROR: .env-test parameter 'slack_channel_develop' is required. See .env.sample, README, or Wiki of Repository." "$msg"
-set -e
+assert_equal "" "$msg"
+
+ENV_FILENAME=.env-test source ./lib/env.sh
+assert_equal "covid19-surveyor-dev" "$slack_channel_develop" # 省略するとデフォルト値が入ってくる.
 
 
 # .env 内パラメーター正常読み取りチェック


### PR DESCRIPTION
関連: #242

付随するテストコードを修正。

また、slack_channel_develop を省略するとデフォルト値の "covid19-surveyor-dev" が入るようにしておきました。利便性的にあると良いかなと。