### PR TITLE
pdfを収集するのを辞めたい

### DIFF
--- a/accepted-file-extensions.json
+++ b/accepted-file-extensions.json
@@ -4,7 +4,6 @@
     "cgi",
     "htm",
     "html",
-    "pdf",
     "php"
   ]
 }


### PR DESCRIPTION
拡張子pdfがクローラーの収集対象になっているが、
PDFファイルは容量が大きいため、
- HTTP通信に時間が掛かり、クローリング時間が長くなる
- ディスク容量をたくさん使う

以上の理由からPDFを除外したい。