### PR TITLE
`wget.sh` のオプションにコメントをつける

### DIFF
--- a/crawler/wget.sh
+++ b/crawler/wget.sh
@@ -107,7 +107,7 @@ main() {
       –-no-parent \
       --page-requisites \
       --convert-links \
-      –-no-clobber \
+      --timestamping \
       --random-wait \
       --quiet \
       --show-progress \

--- a/crawler/wget.sh
+++ b/crawler/wget.sh
@@ -83,8 +83,6 @@ main() {
         #  –-no-parent \
     # ページ表示のために必要な関連ファイルもダウンロードする
         # --page-requisites \
-    # リンクを相対リンクにする
-        #  --convert-links \
     # 既にダウンロード済みのファイルは再取得しない
     # --timestampingとは同時に指定できない
         #  –-no-clobber \
@@ -106,7 +104,6 @@ main() {
       --level 2 \
       –-no-parent \
       --page-requisites \
-      --convert-links \
       --timestamping \
       --random-wait \
       --quiet \

--- a/crawler/wget.sh
+++ b/crawler/wget.sh
@@ -72,8 +72,48 @@ main() {
     ext=$(jq -r .ext[] ./accepted-file-extensions.json | tr '\n' '|' | rev | cut -c 2- | rev)
 
     pushd www-data
-    # urls配列の中身をwgetに渡している
-    echo ${urls} | xargs -n 1 echo | xargs -P 16 -I{} wget -l 2 -r -q --show-progress --accept-regex "\.(${ext})$" --no-check-certificate {}
+    # xargsでurls配列の中身をwgetに渡している
+    # wgetのオプション
+    # https://www.hariguchi.org/info/ja/wget-1.5.3/wget-ja.html
+    # リンクを辿る
+        #  --recursive \
+    # リンクを2段階まで辿る
+        #  --level 2 \
+    # 親ページへのリンクは辿らない
+        #  –-no-parent \
+    # ページ表示のために必要な関連ファイルもダウンロードする
+        # --page-requisites \
+    # リンクを相対リンクにする
+        #  --convert-links \
+    # 既にダウンロード済みのファイルは再取得しない
+    # --timestampingとは同時に指定できない
+        #  –-no-clobber \
+    # タイムスタンプを比較し、変更されていないならダウンロードしない
+    # --no-clobberとは同時に指定できない
+        #  --timestamping \
+    # 相手先サーバーに負荷を掛けないようにランダムに待つ
+        #  --random-wait \
+    # 詳細なログ出力をしない
+        #  --quiet \
+    # 進捗だけはログ出力する
+        #  --show-progress \
+    # この正規表現にマッチするURLだけダウンロードする
+        #  --accept-regex "\.(${ext})$" \
+    # サーバーの証明書エラーを無視する
+        #  --no-check-certificate \
+    echo ${urls} | xargs -n 1 echo | xargs -P 16 -I{} wget \
+      --recursive \
+      --level 2 \
+      –-no-parent \
+      --page-requisites \
+      --convert-links \
+      –-no-clobber \
+      --random-wait \
+      --quiet \
+      --show-progress \
+      --accept-regex "\.(${ext})$" \
+      --no-check-certificate \
+      {}
     echo ${domains} | xargs -n 1 echo | xargs -I{} cp -f ../robots.txt {}
     popd
 }


### PR DESCRIPTION
`wget.sh` のオプションにコメントをつける。
ショートネームオプションはわかりにくいのでロングネームオプションにした。

加えて、クローリング時に必要そうなオプションを追加した。