### PR TITLE
ミラーサイトを構築したい場合用の `accept-ext.json` のsample `accept-ext-mirroring.json.sample` を追加する

### DIFF
--- a/accept-ext-mirroring.json.sapmle
+++ b/accept-ext-mirroring.json.sapmle
@@ -1,0 +1,18 @@
+{
+  "ext": [
+    "htm",
+    "html",
+    "aspx",
+    "cgi",
+    "php",
+    "css",
+    "js",
+    "json",
+    "jpg",
+    "jpeg",
+    "png",
+    "gif",
+    "webp",
+    "svg"
+  ]
+}


### PR DESCRIPTION
現状の `accept-ext.json.sample` はWebサイトのテキスト本文を分析することを目的としているが、
このクローラーを使えば元のサーバーに負荷を掛けないことを目的とした人間が閲覧可能な状態のミラーサイトを構築することも可能なので、
そのための拡張子を列挙した `accept-ext-mirroring.json.sample` を追加する。


## 動作確認

http://www.city.taito.lg.jp.gov.yuiseki.net/

が閲覧できることを確認した